### PR TITLE
GitHub Action for Helm Deployment

### DIFF
--- a/.github/workflows/build_application.yml
+++ b/.github/workflows/build_application.yml
@@ -1,6 +1,6 @@
 # This workflow runs tests, builds, and publishes the images. It performs no deployment.
 # It runs on all branches when code is pushed to ensure tests pass and images are available for testing purposes.
-name: 
+name: Build & Test Meet@Mensa
 
 # Run on all branches except main
 on:
@@ -19,9 +19,3 @@ jobs:
   build:
     name: Build & Publish Images
     uses: ./.github/workflows/docker_build.yml
-
-  # Call the kubernetes_deploy workflow to deploy to Rancher
-  deploy:
-    name: Deploy to Kubernetes Cluster
-    needs: build # wait for build to complete before running
-    uses: ./.github/workflows/kubernetes_deploy.yml

--- a/.github/workflows/build_application.yml
+++ b/.github/workflows/build_application.yml
@@ -1,13 +1,12 @@
-# This workflow builds and publishes the images, then deploys them to the Kubernetes cluster.
-# It runs only when code is pushed to the main branch, and is thus considered ready for production.
-name: Deploy Meet@Mensa
+# This workflow runs tests, builds, and publishes the images. It performs no deployment.
+# It runs on all branches when code is pushed to ensure tests pass and images are available for testing purposes.
+name: 
 
+# Run on all branches except main
 on:
   push:
-    branches:
+    branches-ignore:
       - main
-      # TODO: Set to only run when pushed to main before PR is merged
-      - feature/github-actions-helm
 
 jobs:
 
@@ -24,5 +23,5 @@ jobs:
   # Call the kubernetes_deploy workflow to deploy to Rancher
   deploy:
     name: Deploy to Kubernetes Cluster
-    needs: build
+    needs: build # wait for build to complete before running
     uses: ./.github/workflows/kubernetes_deploy.yml

--- a/.github/workflows/deploy_application.yml
+++ b/.github/workflows/deploy_application.yml
@@ -27,6 +27,8 @@ jobs:
     name: Deploy to Kubernetes Cluster
     needs: build # wait for build to complete before running
     uses: ./.github/workflows/kubernetes_deploy.yml
+    secrets:
+      KUBECONFIG: ${{ secrets.KUBECONFIG }}
 
   # Call the aws_deploy workflow to deploy to AWS
   # deploy_aws:

--- a/.github/workflows/deploy_application.yml
+++ b/.github/workflows/deploy_application.yml
@@ -27,7 +27,7 @@ jobs:
     name: Deploy to Kubernetes Cluster
     needs: build # wait for build to complete before running
     uses: ./.github/workflows/kubernetes_deploy.yml
-    secrets:
+    secrets: # Pass KUBECONFIG to called workflow
       KUBECONFIG: ${{ secrets.KUBECONFIG }}
 
   # Call the aws_deploy workflow to deploy to AWS

--- a/.github/workflows/deploy_application.yml
+++ b/.github/workflows/deploy_application.yml
@@ -22,7 +22,13 @@ jobs:
     uses: ./.github/workflows/docker_build.yml
 
   # Call the kubernetes_deploy workflow to deploy to Rancher
-  deploy:
+  deploy_kubernetes:
     name: Deploy to Kubernetes Cluster
-    needs: build
+    needs: build # wait for build to complete before running
     uses: ./.github/workflows/kubernetes_deploy.yml
+
+  # Call the aws_deploy workflow to deploy to AWS
+  # deploy_aws:
+  #  name: Deploy to AWS
+  #  needs: build
+  #  uses: ./.github/workflows/aws_deploy.yml

--- a/.github/workflows/deploy_application.yml
+++ b/.github/workflows/deploy_application.yml
@@ -12,6 +12,8 @@ jobs:
     name: Build & Publish Images
     uses: ./.github/workflows/docker_build.yml
 
+  # Call the kubernetes_deploy workflow to deploy to Rancher
   deploy:
     name: Deploy to Kubernetes Cluster
+    needs: build
     uses: ./.github/workflows/kubernetes_deploy.yml

--- a/.github/workflows/deploy_application.yml
+++ b/.github/workflows/deploy_application.yml
@@ -3,7 +3,7 @@ name: Deploy Meet@Mensa
 
 on:
   push:
-  # TODO: Only run when pushed to main
+  # TODO: Set to only run when pushed to main before PR is merged
 
 jobs:
 

--- a/.github/workflows/deploy_application.yml
+++ b/.github/workflows/deploy_application.yml
@@ -1,0 +1,17 @@
+# This workflow builds and publishes the images, then deploys them to the Kubernetes cluster.
+name: Deploy Meet@Mensa
+
+on:
+  push:
+  # TODO: Only run when pushed to main
+
+jobs:
+
+  # Call the docker_build workflow to build and publish images
+  build:
+    name: Build & Publish Images
+    uses: ./.github/workflows/docker_build.yml
+
+  deploy:
+    name: Deploy to Kubernetes Cluster
+    uses: ./.github/workflows/kubernetes_deploy.yml

--- a/.github/workflows/deploy_application.yml
+++ b/.github/workflows/deploy_application.yml
@@ -3,6 +3,7 @@
 name: Deploy Meet@Mensa
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/deploy_application.yml
+++ b/.github/workflows/deploy_application.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-      # TODO: Set to only run when pushed to main before PR is merged
-      - feature/github-actions-helm
 
 jobs:
 

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -2,7 +2,7 @@
 name: Build Docker Images
 
 on:
-  push:
+  workflow_call:
 
 # List of jobs to be run
 jobs:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,19 +1,22 @@
 # This workflow should build docker images every time code is pushed to the repository
-name: Build Docker Images
+name: Build and Publish Docker Images
 
+# This workflow is triggered only when called by another workflow
 on:
   workflow_call:
 
-# List of jobs to be run
 jobs:
 
   build:
     name: Build Docker Images
     runs-on: ubuntu-latest
-    strategy: # Use a matrix strategy to run the build process for all our containers
+
+    # Use a matrix strategy to run the build process for all our containers
+    strategy:
       matrix:
         # Add any future services relative paths from . here
         service: [client, server/chat, server/gateway, server/matching, server/user, genai]
+    
     steps:
 
       # Use pre-existing action to login to GHCR.io

--- a/.github/workflows/kubernetes_deploy.yml
+++ b/.github/workflows/kubernetes_deploy.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Load Kubeconfig
       run: | # TODO: I'm unsure what the label and format for the secret containing the kubernetes token is. Will have to ask the Jan on Tuesday.
         mkdir -p ~/.kube
-        echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+        printf "%s" "${{ secrets.KUBECONFIG }}" > ~/.kube/config
         kubectl config get-contexts
         kubectl config current-context
 

--- a/.github/workflows/kubernetes_deploy.yml
+++ b/.github/workflows/kubernetes_deploy.yml
@@ -1,0 +1,39 @@
+# This workflow should deploy meet@mensa to the chair's Rancher Kubernetes cluster every time code is pushed into main branch
+name: Deploy to Kubernetes Cluster
+
+# Currently, this workflow can only be triggered manually.
+on:
+  workflow_dispatch:
+
+jobs:
+
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+    # Checkout git repo
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    # Use Azure's kubectl installation action
+    - name: Install Kubectl
+      uses: azure/setup-kubectl@v4
+      with:
+        version: latest
+
+    # Use Azure's helm installation action
+    - name: Install Helm
+      uses: azure/setup-helm@v4.3.0
+      with:
+        version: latest
+
+    # Copy the details of Kubeconfig to enable authentication with the Rancher cluster
+    - name: Load Kubeconfig
+      run: | # TODO: I'm unsure what the label and format for the secret containing the kubernetes token is. Will have to ask the Jan on Tuesday.
+        mkdir -p ~/.kube
+        echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+
+    # Run helm upgrade to upgrade deployment
+    - name: Upgrade Deployment with Helm
+      run: |
+        helm upgrade --install meetatmensa ./deployment/k8s -n devoops

--- a/.github/workflows/kubernetes_deploy.yml
+++ b/.github/workflows/kubernetes_deploy.yml
@@ -1,7 +1,7 @@
 # This workflow should deploy meet@mensa to the chair's Rancher Kubernetes cluster every time code is pushed into main branch
 name: Deploy to Kubernetes Cluster
 
-# Currently, this workflow can only be triggered manually.
+# This workflow is triggered only when called by another workflow
 on:
   workflow_call:
 

--- a/.github/workflows/kubernetes_deploy.yml
+++ b/.github/workflows/kubernetes_deploy.yml
@@ -4,6 +4,7 @@ name: Deploy to Kubernetes Cluster
 # Currently, this workflow can only be triggered manually.
 on:
   workflow_dispatch:
+  push:
 
 jobs:
 

--- a/.github/workflows/kubernetes_deploy.yml
+++ b/.github/workflows/kubernetes_deploy.yml
@@ -32,6 +32,7 @@ jobs:
       run: | # TODO: I'm unsure what the label and format for the secret containing the kubernetes token is. Will have to ask the Jan on Tuesday.
         mkdir -p ~/.kube
         echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+        kubectl config current-context
 
     # Run helm upgrade to upgrade deployment
     - name: Upgrade Deployment with Helm

--- a/.github/workflows/kubernetes_deploy.yml
+++ b/.github/workflows/kubernetes_deploy.yml
@@ -4,7 +4,6 @@ name: Deploy to Kubernetes Cluster
 # Currently, this workflow can only be triggered manually.
 on:
   workflow_dispatch:
-  push:
 
 jobs:
 

--- a/.github/workflows/kubernetes_deploy.yml
+++ b/.github/workflows/kubernetes_deploy.yml
@@ -32,6 +32,7 @@ jobs:
       run: | # TODO: I'm unsure what the label and format for the secret containing the kubernetes token is. Will have to ask the Jan on Tuesday.
         mkdir -p ~/.kube
         echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+        kubectl config get-contexts
         kubectl config current-context
 
     # Run helm upgrade to upgrade deployment

--- a/.github/workflows/kubernetes_deploy.yml
+++ b/.github/workflows/kubernetes_deploy.yml
@@ -5,6 +5,11 @@ name: Deploy to Kubernetes Cluster
 on:
   workflow_call:
 
+    # Pass KUBECONFIG as a secret
+    secrets:
+      KUBECONFIG:
+        required: true
+
 jobs:
 
   deploy:

--- a/.github/workflows/kubernetes_deploy.yml
+++ b/.github/workflows/kubernetes_deploy.yml
@@ -31,7 +31,10 @@ jobs:
     - name: Load Kubeconfig
       run: | # TODO: I'm unsure what the label and format for the secret containing the kubernetes token is. Will have to ask the Jan on Tuesday.
         mkdir -p ~/.kube
+        ls ~/.kube
         printf "%s" "${{ secrets.KUBECONFIG }}" > ~/.kube/config
+        ls ~/.kube
+        head -2 ~/.kube/config
         kubectl config get-contexts
         kubectl config current-context
 

--- a/.github/workflows/kubernetes_deploy.yml
+++ b/.github/workflows/kubernetes_deploy.yml
@@ -34,14 +34,9 @@ jobs:
 
     # Copy the details of Kubeconfig to enable authentication with the Rancher cluster
     - name: Load Kubeconfig
-      run: | # TODO: I'm unsure what the label and format for the secret containing the kubernetes token is. Will have to ask the Jan on Tuesday.
+      run: |
         mkdir -p ~/.kube
-        ls ~/.kube
         printf "%s" "${{ secrets.KUBECONFIG }}" > ~/.kube/config
-        ls ~/.kube
-        head -2 ~/.kube/config
-        kubectl config get-contexts
-        kubectl config current-context
 
     # Run helm upgrade to upgrade deployment
     - name: Upgrade Deployment with Helm

--- a/.github/workflows/kubernetes_deploy.yml
+++ b/.github/workflows/kubernetes_deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to Kubernetes Cluster
 
 # Currently, this workflow can only be triggered manually.
 on:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
 


### PR DESCRIPTION
## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [ ] 🚀 Performance improvement
- [x] ✅ Test addition/update
- [x] 🧹 Chore/maintenance
- [ ] Other (please describe):

## Changes

- [x] Created GitHub action (`kubernetes_deploy.yml`) to deploy application to Kubernetes cluster
- [x] Set build (`docker_build.yml`) and deploy (`kubernetes_deploy.yml`) actions to trigger only when called by another workflow
- [x] Created "Orchestration" workflows (`build_application.yml` and `deploy_application.yml`) to handle potential race conditions (see Additional Notes)

## Checklist

<!-- Mark the items you've completed with an "x" -->

- [ ] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues

Related #38 #36 #35 #34


## Additional Notes

This PR is currently a draft. Please do not merge.

### Authentication to Rancher

This PR currently fails to deploy to Rancher. This is due to being unable to load the contents of Kubeconfig. As Students, we are unable to create our own secrets on this repository, which is necessary since Kubeconfig contains authentication information.

This will be discussed with @Jan-Thurner at our meeting on Tuesday.

### Race Conditions

Existing workflows have been set to run only when called by the new "orchestration workflows":

_steps with () are unimplemented_

#### `build_application.yml`
- Runs when code is pushed to any branch _except_ `main`
- (Run Tests) -> Build Images -> Publish Images

#### `deploy_application.yml`
- Runs only when code is pushed to `main` (i.e. deemed ready for production)
- (Run Tests) -> Build Images -> Publish Images -> Deploy to Kubernetes & (Deploy to AWS)

This is done to avoid race conditions as identified by @a-kori:
> If build & deploy actions trigger at the same time, race conditions decide which image gets deployed