### PR TITLE
Feature: Use t3 large for AWS deployment

### DIFF
--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -31,7 +31,7 @@ variable "ami_id" {
 variable "instance_type" {
   description = "Instance type for the EC2 instance"
   type        = string
-  default     = "t3.small"
+  default     = "t3.large"
 }
 
 variable "aws_ec2_private_key" {


### PR DESCRIPTION
## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Code refactor
- [ ] 📝 Documentation update
- [ ] 🚀 Performance improvement
- [ ] ✅ Test addition/update
- [ ] 🧹 Chore/maintenance
- [ ] 📐 API Spec update
- [ ] Other (please describe):

## Changes

- we encountered performance issues with t3.small and the service became unavailable after some time
- according to the #tech-support channel on Artemis other groups had the same experience and solved it with moving to an even larger instance with double the RAM as the previously used t3.small
